### PR TITLE
⚙️ lint-staged の対象を .js like なのから .md 以外 に変えた

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepare": "husky install"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
+    "!*.{md,json}": [
       "eslint",
       "prettier --check"
     ]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepare": "husky install"
   },
   "lint-staged": {
-    "!*.{md,json}": [
+    "*.{js,jsx,ts,tsx,html,css}": [
       "eslint",
       "prettier --check"
     ]


### PR DESCRIPTION
fix #13

.md と .json 以外にした
md はなんか日本語との相性が悪いらしくて、.json は single quote のエラー出るから外した
該当の issue は html が対象外だったのが原因だった